### PR TITLE
add -git suffix to pkgbase

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Andrea Scarpino <andrea@archlinux.org>
 # Contributor: Pierre Schmitz <pierre@archlinux.de>
 
-pkgbase=oxygen-icons
+pkgbase=oxygen-icons-git
 #pkgname=(oxygen-icons oxygen-icons-svg)
 conflicts=(oxygen-icons oxygen-icons-svg)
 provides=(oxygen-icons oxygen-icons-svg)
@@ -16,7 +16,7 @@ arch=(any)
 url='https://community.kde.org/Frameworks'
 license=(LGPL)
 makedepends=(extra-cmake-modules-git qt5-base)
-#source=(https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgbase}5-$pkgver.tar.xz{,.sig})
+#source=(https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgbase%-git}5-$pkgver.tar.xz{,.sig})
 #sha256sums=('2f747c4daf561306b25c347cb3a716bec32093ab8bd3e3ab8fbceed89981eec7'
 #            'SKIP')
 #validpgpkeys=(53E6B47B45CEA3E0D5B7457758D0EE648A48B3BB) # David Faure <faure@kde.org>
@@ -25,13 +25,13 @@ source=("git+https://github.com/KDE/${pkgname%-git}5#branch=kf5")
 sha256sums=('SKIP')
 
 pkgver() {
-  cd ${pkgname%-git}5
+  cd "${pkgname%-git}5"
   _ver="$(grep -m1 'set(KF_VERSION' CMakeLists.txt | cut -d '"' -f2 | tr - .)"
   echo "${_ver}_r$(git rev-list --count HEAD).g$(git rev-parse --short HEAD)"
 }
 
 build() {
-  cmake -B build -S ${pkgbase}5
+  cmake -B build -S "${pkgbase%-git}5"
   cmake --build build
 }
 
@@ -45,7 +45,7 @@ package_oxygen-icons-git() {
 package_oxygen-icons-svg-git() {
   pkgdesc='The Oxygen Icon Theme (Scalable Vector Graphics)'
 
-  cd ${pkgbase}5
+  cd "${pkgbase%-git}5"
   find scalable -type f ! -name '*.sh' -exec \
     install -D -m644 "{}" "$pkgdir"/usr/share/icons/oxygen/{} \;
 }


### PR DESCRIPTION
This change prevents `oxygen-icons` from being listed by the toolbox `find-discarded` command.